### PR TITLE
EN-463: Run terraform validate on each unique folder

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,4 +8,4 @@
   files: \.tf$
   exclude: \.+.terraform\/.*$
   require_serial: true
-  args: [--azurerm-provider-version=2.25.0]
+  args: []

--- a/hooks/terraform-validate.sh
+++ b/hooks/terraform-validate.sh
@@ -5,38 +5,39 @@
 # This provider requires an explicit `features` block which in most cases is supplied by a super module.
 # See: https://github.com/hashicorp/terraform/pull/24896
 
-function main() {
-  local azurerm_provider_version="2.25.0"
-
-  if [[ "$1" = "--azurerm-provider-version"* ]]; then
-    azurerm_provider_version="${1//--azurerm-provider-version=/}"
-  fi
-
-  for dir in $(echo "$@" | xargs -n1 dirname | sort -u | uniq); do
-    local -r inline_provider_match="$(grep 'provider "azurerm" {' "$dir/main.tf")"
-    if [[ -n "$inline_provider_match" ]]; then
-      continue
-    fi
-
-    pushd "$dir" >/dev/null || exit 1
-      if [ -n "$azurerm_provider_version" ]; then
-        cat << EOF > provider.tf
+readonly PROVIDER_HCL=<<_EOF_
 provider "azurerm" {
   features {}
 }
 provider "aws" {
   region = "us-east-1"
 }
-EOF
-      fi
-      terraform init -backend=false
-      terraform validate
-      local -r result="$?"
-      rm provider.tf
-      # TODO: Make sure the provider.tf gets removed.
+_EOF_
+
+function cleanup() {
+  git --no-pager status --untracked-files=all "provider.tf" "*/provider.tf" --porcelain=v2 | xargs rm -f
+}
+export -f cleanup;
+
+function main() {
+  trap 'cleanup' exit
+  local result=0;
+
+  for dir in $(echo "$@" | xargs -n1 dirname | sort -u | uniq); do
+    pushd "$dir" >/dev/null || exit 1
+    if ! grep -q -R --include='*.tf' -E '^provider "(azurerm|aws)" {' .; then
+      echo "$PROVIDER_HCL" | tee provider.tf >/dev/null
+    fi
+
+    terraform init -backend=false >/dev/null
+    terraform validate -json
+    if [[ $result -gt 0 ]];
+    then result="$?"
+    fi
     popd >/dev/null || exit 1
-    exit "$result"
   done
+
+  exit "$result"
 }
 
 main "$@"


### PR DESCRIPTION
Previously this was exiting after the first directory.

This also evaluates the directory for a .tf that contains a provider,
only adding a temporary provider if none are found.